### PR TITLE
Remove JST default timezone overwrite

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -36,7 +36,6 @@ patch(libraries)
 s3 = boto3.client('s3')
 
 # consts
-os.environ['TZ'] = "Asia/Tokyo"
 ES_TIMEOUT = 30
 BULK_CHUNK_SIZE = 500
 


### PR DESCRIPTION
TZ should not be touched from within Lambda. We set TZ by modifying Lambda Function envvars in module and not source.