### PR TITLE
Fix empty whitelist case

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -45,8 +45,13 @@ FAILED_LOG_S3_PATH_PREFIX = os.environ['FAILED_LOG_S3_PREFIX']
 
 LOG_TYPE_FIELD: str = os.environ['LOG_TYPE_FIELD']
 LOG_TIMESTAMP_FIELD: str = os.environ['LOG_TIMESTAMP_FIELD']
-LOG_TYPE_FIELD_WHITELIST: set = set(str(os.environ['LOG_TYPE_WHITELIST']).split(','))
 LOG_TYPE_UNKNOWN_PREFIX: str = os.environ['LOG_TYPE_UNKNOWN_PREFIX']
+
+WHITELIST: str = str(os.environ['LOG_TYPE_WHITELIST'])
+if WHITELIST == "":
+    LOG_TYPE_FIELD_WHITELIST: set = set()
+else:
+    LOG_TYPE_FIELD_WHITELIST: set = set(WHITELIST.split(','))
 
 ELASTICSEARCH_HOST = os.environ['ES_HOST']
 INDEX_NAME_PREFIX = os.environ['INDEX_NAME_PREFIX']


### PR DESCRIPTION
Empty whitelist should have 0 length. Non-zero length whitelists trigger filtering logic, having an empty string in a set results in all logs being skipped.

```
$ export LOG_TYPE_WHITELIST=""
$ python3
Python 3.7.4 (default, Jul  9 2019, 18:13:23) 
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import os 
>>> LOG_TYPE_FIELD_WHITELIST: set = set(str(os.environ['LOG_TYPE_WHITELIST']).split(','))
>>> LOG_TYPE_FIELD_WHITELIST
{''}
>>> len(LOG_TYPE_FIELD_WHITELIST)
1
{''}
>>> len(set())
0
```

This PR fixes `LOG_TYPE_FIELD_WHITELIST ` set initialization.