### PR TITLE
Ignore boto3 updates in pyup

### DIFF
--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,6 +1,7 @@
+boto3 # pyup: ignore
+
 aws-kinesis-agg==1.1.2
 aws-xray-sdk==2.4.3
-boto3==1.12.12
 certifi==2019.11.28
 elasticsearch==7.5.1
 python-dateutil==2.8.1


### PR DESCRIPTION
Lambda runtime has latest, and for deploy packages we do not vendor boto anyway.